### PR TITLE
Fix camera rotate and zoom

### DIFF
--- a/include/camera.h
+++ b/include/camera.h
@@ -33,7 +33,7 @@ public:
   Vector3f getForwardVector(void) const;
   Vector3f getUpVector(void) const;
   Vector3f getRightVector(void) const;
-  Vector3f getRay_W(float width, float height, double x, double y) const;
+  Vector3f computeRayWorld(float width, float height, double x, double y) const;
 
   void updatePosition(const Vector3f& p);
   void updateLookat(const Vector3f& newLookat);

--- a/include/label_studio.h
+++ b/include/label_studio.h
@@ -95,7 +95,7 @@ public:
 
   void mouseMoved(double x, double y) {
     moved = true;
-    
+
     if (dragging) {
       float diffX = (x - prevX);
       float diffY = (y - prevY);
@@ -105,11 +105,11 @@ public:
 
       prevX = x;
       prevY = y;
-      
+
     }
     pointingAt = sceneModel.traceRay(x, y);
-  
-    
+
+
   }
 
   void scroll(double xoffset, double yoffset) {

--- a/include/scene_model.h
+++ b/include/scene_model.h
@@ -31,7 +31,7 @@ public:
   SceneModel(const std::string& datasetFolder);
 
   std::shared_ptr<geometry::TriangleMesh> getMesh() const;
-  std::shared_ptr<Camera> getCamera() const;
+  const Camera& getCamera() const;
   std::optional<Vector3f> traceRay(double x, double y);
 
   const std::vector<Vector3f>& getKeypoints() const { return keypoints; };

--- a/include/studio_view.h
+++ b/include/studio_view.h
@@ -12,7 +12,7 @@ public:
   std::shared_ptr<views::MeshView> meshView;
 
   StudioView(const SceneModel& model);
-  void render(std::shared_ptr<Camera> camera) const override;
+  void render(const Camera& camera) const override;
 };
 
 #endif

--- a/include/views/mesh_view.h
+++ b/include/views/mesh_view.h
@@ -46,7 +46,7 @@ public:
   void addObject(std::shared_ptr<MeshDrawable> obj);
   void popObject() { objects.pop_back(); }
 
-  virtual void render(std::shared_ptr<Camera> camera) const override;
+  virtual void render(const Camera& camera) const override;
 };
 
 }

--- a/include/views/view.h
+++ b/include/views/view.h
@@ -7,7 +7,7 @@ namespace views {
 using namespace Eigen;
 class View {
 public:
-  virtual void render(std::shared_ptr<Camera> camera) const = 0;
+  virtual void render(const Camera& camera) const = 0;
 };
 
 }

--- a/src/camera.cc
+++ b/src/camera.cc
@@ -12,8 +12,6 @@ Camera::Camera(Vector3f initialLookat, float distance): lookat(initialLookat) {
     viewMatrix.translation() = - (viewMatrix.linear() * position);
 }
 
-
-
 Matrix3f Camera::getCameraRotation(const Vector3f& forwardVector) const {
     Matrix3f cameraRotation;
     cameraRotation.col(2) = (-forwardVector).normalized();
@@ -22,20 +20,19 @@ Matrix3f Camera::getCameraRotation(const Vector3f& forwardVector) const {
     return cameraRotation;
 }
 
-
 Vector3f Camera::getForwardVector(void) const {
     return - (orientation * Vector3f::UnitZ());
 }
 
 Vector3f Camera::getUpVector(void) const {
-return orientation * Vector3f::UnitY();
+    return orientation * Vector3f::UnitY();
 }
 
 Vector3f Camera::getRightVector(void) const {
-return orientation * Vector3f::UnitX();
+    return orientation * Vector3f::UnitX();
 }
 
-Vector3f Camera::getRay_W(float width, float height, double x, double y) const {
+Vector3f Camera::computeRayWorld(float width, float height, double x, double y) const {
     float aspectRatio = width / height;
     float pX = (2.0f * (x / width) - 1.0f) * std::tan(fov / 2.0f * M_PI / 180) * aspectRatio;
     float pY = (1.0f - 2.0f * (y / height)) * std::tan(fov / 2.0f * M_PI / 180);
@@ -44,7 +41,7 @@ Vector3f Camera::getRay_W(float width, float height, double x, double y) const {
     return ray_W;
 }
 
-void Camera::updatePosition(const Vector3f& p) {   
+void Camera::updatePosition(const Vector3f& p) {
     setPosition(p);
 }
 
@@ -53,7 +50,7 @@ void Camera::updateLookat(const Vector3f& newLookat) {
     if (!lookat.isApprox(position)) {
         Vector3f newForwardVector = (lookat - position).normalized();
         Vector3f up = getUpVector();
-        
+
         Matrix3f cameraRotation(getCameraRotation(newForwardVector));
         setOrientation(Quaternionf(cameraRotation));
     }
@@ -69,15 +66,13 @@ void Camera::rotateAroundTarget(const Quaternionf& q) {
     Quaternionf qa(newViewMatrix.linear());
     qa = qa.conjugate();
     setOrientation(qa);
-    setPosition(- (qa * viewMatrix.translation()) );
+    setPosition(-(qa * viewMatrix.translation()));
     setViewMatrix(newViewMatrix);
 }
 
-
 void Camera::zoom(float d) {
     float norm = (getPosition() - lookat).norm();
-    if(norm > d)
-    {
+    if(norm > d) {
         Affine3f newViewMatrix;
         setPosition(getPosition() + getForwardVector() * d);
         Quaternionf q = getOrientation().conjugate();

--- a/src/scene_model.cc
+++ b/src/scene_model.cc
@@ -11,13 +11,13 @@ SceneModel::SceneModel(const std::string& datasetFolder) : datasetPath(datasetFo
 }
 
 std::shared_ptr<geometry::TriangleMesh> SceneModel::getMesh() const { return mesh; }
-std::shared_ptr<Camera> SceneModel::getCamera() const { return camera; }
+const Camera& SceneModel::getCamera() const { return *camera.get(); }
 
 std::optional<Vector3f> SceneModel::traceRay(double x, double y) {
   nanort::Ray<float> ray;
   ray.min_t = 0.0;
   ray.max_t = 1e9f;
-  Vector3f ray_W(camera->getRay_W(float(Width), float(Height), x, y));
+  Vector3f ray_W(camera->computeRayWorld(float(Width), float(Height), x, y));
   Vector3f rayOrigin = camera->getPosition();
 
   ray.org[0] = rayOrigin[0];

--- a/src/studio_view.cc
+++ b/src/studio_view.cc
@@ -6,7 +6,7 @@ StudioView::StudioView(const SceneModel& model) : sceneModel(model) {
   meshView->addObject(meshDrawable);
 }
 
-void StudioView::render(std::shared_ptr<Camera> camera) const {
+void StudioView::render(const Camera& camera) const {
   meshView->render(camera);
 }
 

--- a/src/views/mesh_view.cc
+++ b/src/views/mesh_view.cc
@@ -72,20 +72,20 @@ void MeshView::addObject(std::shared_ptr<MeshDrawable> obj) {
   objects.push_back(obj);
 }
 
-void MeshView::render(std::shared_ptr<Camera> camera) const {
+void MeshView::render(const Camera& camera) const {
   float proj[16];
   float view[16];
 
   bgfx::touch(0);
 
-  auto position = camera->getPosition();
-  auto lookat = camera->getLookat();
-  auto cameraUp = camera->getUpVector();
+  auto position = camera.getPosition();
+  auto lookat = camera.getLookat();
+  auto cameraUp = camera.getUpVector();
 
   const bx::Vec3 at  = { lookat[0], lookat[1], lookat[2] };
   const bx::Vec3 eye = { position[0], position[1], position[2] };
   const bx::Vec3 up = { cameraUp[0], cameraUp[1], cameraUp[2] };
-  bx::mtxProj(proj, camera->fov, float(800)/float(600), 0.1f, 25.0f, bgfx::getCaps()->homogeneousDepth, bx::Handness::Right);
+  bx::mtxProj(proj, camera.fov, float(800)/float(600), 0.1f, 25.0f, bgfx::getCaps()->homogeneousDepth, bx::Handness::Right);
   bx::mtxLookAt(view, eye, at, up, bx::Handness::Right);
 
   bgfx::setViewTransform(0, view, proj);


### PR DESCRIPTION
https://user-images.githubusercontent.com/4254623/115144763-1e8ba800-a057-11eb-94e2-99e7d4cd39d2.mp4

* Changes the mesh coordinates to be right handed/same as in open3d (corresponding dev-workspace PR to follow)
* Improves camera controls (zoom + rotation, adding translation in a follow up PR to avoid clutter)
* Camera math is somewhat inspired from [here](https://gitlab.com/libeigen/eigen/-/blob/master/demos/opengl/camera.cpp) but without the `mViewIsUptodate` convolution spaghetti :spaghetti: 
* The test might be a bit rough (hard coded constant values), happy to get feedback on that
* I hope changing `SceneModel`'s camera to be a `std::shared_ptr` makes sense, mostly wanted to first compute the mesh mean before initializing the camera.