### PR TITLE
Github build test action

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,28 @@
+name: Run tests
+on: [push]
+jobs:
+  Run-Tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+        with:
+          lfs: true
+      - name: Get submodules
+        run: git submodule update --init --recursive
+      - name: List files in the repository
+        run: |
+          ls ${{ github.workspace }}
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake build-essential ninja-build libglfw3-dev libeigen3-dev libgtest-dev
+      - name: Build project
+        run: |
+          mkdir build && cd build
+          cmake .. -DCMAKE_BUILD_TYPE=Release -GNinja
+          ninja build_tests
+      - name: Run tests
+        run: |
+          cd build && ctest -V
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,9 @@
 cmake_minimum_required(VERSION 3.10)
 project(LabelStudio)
 
+find_package(PkgConfig)
+pkg_search_module(Eigen3 REQUIRED eigen3)
 find_package(glfw3 REQUIRED)
-find_package(eigen3 REQUIRED)
 find_package(OpenMP REQUIRED)
 
 set(CMAKE_CXX_STANDARD 20)


### PR DESCRIPTION
Set up a github actions to build project and run tests.

Currently, most of the time is spent building bgfx. Would be great to come up with a solution that would not require always building it from scratch. We could package it and install through the package manager. Another option would be a customer container image that comes with it installed in system directories and the project could link against it.

I kind of like that the whole project can be built in a couple commands. Kind of sucks that c++ doesn't have a decent package manager, but we could look into conan or something like that.