### PR TITLE
Statically link boost and openmp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,20 +5,21 @@ if (CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.3)
     message(FATAL_ERROR "GCC version must be at least 9.3")
 endif()
 
+set(VERSION_MAJOR 0)
+set(VERSION_MINOR 1)
+set(VERSION_PATCH 1)
+set(Boost_USE_STATIC_LIBS ON)
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+set(BGFX_BUILD_TOOLS ON)
+set(BGFX_BUILD_EXAMPLES OFF)
+
 find_package(PkgConfig)
 pkg_search_module(Eigen3 REQUIRED eigen3)
 find_package(glfw3 REQUIRED)
 find_package(OpenMP REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system filesystem)
 
-set(VERSION_MAJOR 0)
-set(VERSION_MINOR 1)
-set(VERSION_PATCH 1)
-set(CMAKE_CXX_STANDARD 20)
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-
-set(BGFX_BUILD_TOOLS ON)
-set(BGFX_BUILD_EXAMPLES OFF)
 
 include_directories(include ${eigen3_INCLUDE_DIRS} ${boost_INCLUDE_DIRS})
 add_subdirectory(submodules/bgfx)
@@ -33,11 +34,11 @@ file(GLOB_RECURSE BGFX_COMMON submodules/bgfx/bgfx/examples/common/font/*.cpp
   submodules/bgfx/bgfx/examples/common/cube_atlas.cpp)
 add_executable(studio ${SOURCE_FILES} ${BGFX_COMMON} apps/desktop.cc)
 target_compile_options(studio PRIVATE -Wall)
-target_link_libraries(studio bgfx bx bimg glfw ${eigen3_LIBRARIES} OpenMP::OpenMP_CXX ${Boost_LIBRARIES})
+target_link_libraries(studio PRIVATE bgfx bx bimg glfw ${eigen3_LIBRARIES} ${OpenMP_CXX_LIBRARY} ${Boost_LIBRARIES})
 
 add_executable(preview ${SOURCE_FILES} ${BGFX_COMMON} apps/preview.cc)
 target_compile_options(preview PRIVATE -Wall)
-target_link_libraries(preview bgfx bx bimg glfw ${eigen3_LIBRARIES} OpenMP::OpenMP_CXX ${Boost_LIBRARIES})
+target_link_libraries(preview PRIVATE bgfx bx bimg glfw ${eigen3_LIBRARIES} ${OpenMP_CXX_LIBRARY} ${Boost_LIBRARIES})
 
 file(GLOB_RECURSE SHADER_FILES shaders/fs_*.sc shaders/vs_*.sc)
 add_shaders(studio SHADERS ${SHADER_FILES})


### PR DESCRIPTION
Does not change functionality.

Works on mac, might make sense to test the prebuilt binary (I'll deploy a new build now) on a different mac and make sure ubuntu build, deploy and running works.