### PR TITLE
Bbox translate bugfix

### DIFF
--- a/include/commands/bounding_box.h
+++ b/include/commands/bounding_box.h
@@ -30,7 +30,12 @@ private:
   const Quaternionf newOrientation;
 
 public:
-  MoveBBoxCommand(const BBox& box, const Vector3f& position, const Quaternionf& orientation) : bbox(box), oldPosition(bbox.position), newPosition(position), oldOrientation(bbox.orientation), newOrientation(orientation) {}
+  MoveBBoxCommand(const BBox& box, const Vector3f& position, const Quaternionf& orientation) :
+      bbox(box),
+      oldPosition(bbox.position),
+      newPosition(position),
+      oldOrientation(bbox.orientation),
+      newOrientation(orientation) {}
   void execute(SceneModel& sceneModel) override {
     bbox.position = newPosition;
     bbox.orientation = newOrientation;

--- a/include/views/add_bbox_view.h
+++ b/include/views/add_bbox_view.h
@@ -21,9 +21,8 @@ private:
   std::shared_ptr<views::controls::TranslateControl> sizeControl;
   BBox bboxStart = {.id = -1};
   Vector3f position = Vector3f::Zero();
-  Quaternionf orientation;
+  Quaternionf orientation = Quaternionf::Identity();
   Vector3f dimensions = Vector3f::Zero();
-
 public:
   AddBBoxView(SceneModel& model, Timeline& timeline, int viewId = 0);
   void refresh();

--- a/src/views/add_bbox_view.cc
+++ b/src/views/add_bbox_view.cc
@@ -85,7 +85,7 @@ bool AddBBoxView::leftButtonUp(const ViewContext3D& viewContext) {
     return true;
   }
   if (translateControl->leftButtonUp(viewContext)) {
-    auto command = std::make_unique<commands::MoveBBoxCommand>(bboxStart, position, orientation);
+    auto command = std::make_unique<commands::MoveBBoxCommand>(bboxStart, position, bboxStart.orientation);
     timeline.pushCommand(std::move(command));
     auto bbox = sceneModel.getBoundingBox(sceneModel.activeBBox);
     if (bbox.has_value()) {


### PR DESCRIPTION
Fixes the bug where the bounding box will change orientation when translating a bounding box without first rotating it. Also initialize the bounding boxes such that they stand on the plane that was clicked, not such that the center is at the plane. 