### PR TITLE
Enable tests via flag

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Build project
         run: |
           mkdir build && cd build
-          cmake .. -DCMAKE_BUILD_TYPE=Release -GNinja
+          cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=1 -GNinja
           ninja build_tests
       - name: Run tests
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,8 +73,10 @@ add_dependencies(studio shaders)
 add_dependencies(preview shaders)
 add_dependencies(pointcloud shaders)
 
-enable_testing()
-add_subdirectory(test EXCLUDE_FROM_ALL)
+if (BUILD_TESTS)
+  enable_testing()
+  add_subdirectory(test EXCLUDE_FROM_ALL)
+endif()
 
 install(TARGETS studio DESTINATION bin)
 install(DIRECTORY ${CMAKE_BINARY_DIR}/compiled_shaders DESTINATION share/stray)

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The keyboard shortcuts are:
 
 In your build directory, run:
 ```
-cmake .. &&
+cmake .. -DBUILD_TESTS=1 &&
 make build_tests &&  # or ninja build_tests if using ninja.
 ctest
 ```

--- a/deploy.sh
+++ b/deploy.sh
@@ -19,7 +19,7 @@ echo "building $source_dir in $tmp_dir"
 
 pushd "$tmp_dir"
 
-cmake $source_dir -GNinja -DCMAKE_BUILD_TYPE=Release
+cmake $source_dir -GNinja -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=1
 ninja
 cpack -GZIP
 archive_name="$(find Studio-*.tar.gz)"


### PR DESCRIPTION
Seems that cmake is unable to find gtest headers when installed via homebrew (at least on my old macbook air), however seems to be working on in the gh action. Nevertheless a flag to enable building the tests does not hurt.