### PR TITLE
Remove bvh intialization from assert

### DIFF
--- a/include/camera.h
+++ b/include/camera.h
@@ -6,9 +6,9 @@ using namespace Eigen;
 
 class SceneCamera {
 public:
+  Eigen::Matrix3f cameraMatrix;
   int imageWidth;
   int imageHeight;
-  Eigen::Matrix3f cameraMatrix;
 
   SceneCamera(const std::filesystem::path intrinsicsPath);
   SceneCamera(const Eigen::Matrix3f cameraMatrix, double width, double height);

--- a/src/controllers/studio_view_controller.cc
+++ b/src/controllers/studio_view_controller.cc
@@ -178,6 +178,7 @@ bool StudioViewController::keypress(char character, const InputModifier mod) {
   } else if (mod == ModShift && character == '2') {
     pointCloudView.loadPointCloud();
     sceneModel.activeView = active_view::PointCloudView;
+    return true;
   } else if (character == 'K') {
     sceneModel.activeToolId = AddKeypointToolId;
     return true;

--- a/src/geometry/ray_trace_cloud.cc
+++ b/src/geometry/ray_trace_cloud.cc
@@ -1,4 +1,5 @@
 #include "geometry/ray_trace_cloud.h"
+#include <iostream>
 
 using namespace geometry;
 using namespace particle_tracing;
@@ -11,7 +12,11 @@ RayTraceCloud::RayTraceCloud(std::shared_ptr<geometry::PointCloud> pc, float& si
   RowMatrixf vertices = pointCloud->points;
   SphereGeometry sphereGeometry(vertices.data(), 0.01);
   SpherePred spherePredicate(vertices.data());
-  assert(bvh.Build(vertices.rows(), sphereGeometry, spherePredicate, options));
+  bool ret = bvh.Build(vertices.rows(), sphereGeometry, spherePredicate, options);
+  if (!ret) {
+    std::cout << "Failed to initialize bounding volume hierarchy" << std::endl;
+    exit(1);
+  }
 }
 
 Intersection RayTraceCloud::traceRayIntersection(const Vector3f& origin, const Vector3f& direction) const {


### PR DESCRIPTION
The bounding volume hierarchy would not get initialized when running in release mode as the function call inside the assert would not be run. Can now use the point cloud view also in release mode.