### PR TITLE
Normal fix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "submodules/glfw"]
 	path = submodules/glfw
 	url = https://github.com/glfw/glfw
+[submodule "submodules/nanoflann"]
+	path = submodules/nanoflann
+	url = https://github.com/jlblancoc/nanoflann

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,11 @@ if (APPLE)
   set(EXTRA_LIBS ${COCOA_LIBRARY} ${CF_LIBRARY} ${IOKIT_LIBRARY})
 endif(APPLE)
 
-include_directories(include submodules/glfw/include ${eigen3_INCLUDE_DIRS} ${boost_INCLUDE_DIRS})
+include_directories(include
+  submodules/glfw/include
+  submodules/nanoflann/include
+  ${eigen3_INCLUDE_DIRS}
+  ${boost_INCLUDE_DIRS})
 include(cmake/shaders.cmake)
 
 include_directories("submodules/bgfx/bgfx/examples")

--- a/include/camera.h
+++ b/include/camera.h
@@ -6,9 +6,9 @@ using namespace Eigen;
 
 class SceneCamera {
 public:
+  Eigen::Matrix3f cameraMatrix;
   int imageWidth;
   int imageHeight;
-  Eigen::Matrix3f cameraMatrix;
 
   SceneCamera(const std::filesystem::path intrinsicsPath);
   SceneCamera(const Eigen::Matrix3f cameraMatrix, double width, double height);

--- a/include/geometry/ray_trace_cloud.h
+++ b/include/geometry/ray_trace_cloud.h
@@ -1,17 +1,45 @@
 #include <memory>
 #include <optional>
+#include <nanoflann.hpp>
 #define NANORT_ENABLE_PARALLEL_BUILD 1
 #include "3rdparty/nanort.h"
 #include "3rdparty/particle_tracing.h"
 #include "geometry/ray_trace_mesh.h"
 #include "geometry/point_cloud.h"
 
+#include <iostream>
 namespace geometry {
+
+using RowMatrixf = Eigen::Matrix<float, Eigen::Dynamic, 3, Eigen::RowMajor>;
+
+template <typename T>
+struct PCAdaptor {
+  const RowMatrixf& pointCloud;
+  PCAdaptor(const RowMatrixf& pc) : pointCloud(pc) {}
+
+  using coord_t = T;
+  inline uint32_t kdtree_get_point_count() const { return pointCloud.rows(); };
+  inline T kdtree_get_pt(const uint32_t idx, const uint32_t dim) const {
+    RowVector3f vec = pointCloud.row(idx);
+    if (dim == 0) return vec[0];
+    else if(dim == 1) return vec[1];
+    else return vec[2];
+  }
+  template <class BBOX>
+  bool kdtree_get_bbox(BBOX& ) const { return false; }
+};
+
+using KDTree = nanoflann::KDTreeSingleIndexAdaptor<
+  nanoflann::L2_Simple_Adaptor<float, PCAdaptor<float>, float>,
+  PCAdaptor<float>, 3>;
+
 class RayTraceCloud {
 private:
   std::shared_ptr<PointCloud> pointCloud;
   nanort::BVHAccel<float> bvh;
   float& pointSize;
+  PCAdaptor<float> adaptor;
+  KDTree index;
 public:
   RayTraceCloud(std::shared_ptr<geometry::PointCloud> pc, float& pointCloudPointSize);
   std::optional<Vector3f> traceRay(const Vector3f& origin, const Vector3f& direction) const;

--- a/include/view_context_3d.h
+++ b/include/view_context_3d.h
@@ -19,5 +19,4 @@ public:
 
   Vector3f rayWorld() const;
   std::optional<Vector3f> pointingAt;
-  std::optional<Vector3f> pointingAtNormal;
 };

--- a/src/controllers/point_cloud_view_controller.cc
+++ b/src/controllers/point_cloud_view_controller.cc
@@ -188,10 +188,8 @@ void PointCloudViewController::updateViewContext(double x, double y, InputModifi
   auto intersection = sceneModel.traceRayIntersection(viewContext.camera.getPosition(), rayDirection);
   if (intersection.hit) {
     viewContext.pointingAt = intersection.point;
-    viewContext.pointingAtNormal = intersection.normal;
   } else {
     viewContext.pointingAt = {};
-    viewContext.pointingAtNormal = {};
   }
 }
 

--- a/src/controllers/studio_view_controller.cc
+++ b/src/controllers/studio_view_controller.cc
@@ -178,6 +178,7 @@ bool StudioViewController::keypress(char character, const InputModifier mod) {
   } else if (mod == ModShift && character == '2') {
     pointCloudView.loadPointCloud();
     sceneModel.activeView = active_view::PointCloudView;
+    return true;
   } else if (character == 'K') {
     sceneModel.activeToolId = AddKeypointToolId;
     return true;

--- a/src/controllers/studio_view_controller.cc
+++ b/src/controllers/studio_view_controller.cc
@@ -224,13 +224,11 @@ void StudioViewController::updateViewContext(double x, double y, InputModifier m
 
   const Vector3f& rayDirection = viewContext.camera.computeRayWorld(viewContext.width, viewContext.height,
                                                                     viewContext.mousePositionX, viewContext.mousePositionY);
-  auto intersection = sceneModel.traceRayIntersection(viewContext.camera.getPosition(), rayDirection);
-  if (intersection.hit) {
-    viewContext.pointingAt = intersection.point;
-    viewContext.pointingAtNormal = intersection.normal;
+  auto point = sceneModel.traceRay(viewContext.camera.getPosition(), rayDirection);
+  if (point.has_value()) {
+    viewContext.pointingAt = point;
   } else {
     viewContext.pointingAt = {};
-    viewContext.pointingAtNormal = {};
   }
 }
 

--- a/src/geometry/ray_trace_cloud.cc
+++ b/src/geometry/ray_trace_cloud.cc
@@ -4,9 +4,13 @@
 using namespace geometry;
 using namespace particle_tracing;
 
-using RowMatrixf = Eigen::Matrix<float, Eigen::Dynamic, 3, Eigen::RowMajor>;
+const uint32_t FindClosest = 50;
+uint32_t closestIndices[FindClosest];
+float distances[FindClosest];
 
-RayTraceCloud::RayTraceCloud(std::shared_ptr<geometry::PointCloud> pc, float& size) : pointCloud(pc), pointSize(size) {
+RayTraceCloud::RayTraceCloud(std::shared_ptr<geometry::PointCloud> pc, float& size) : pointCloud(pc), pointSize(size),
+    adaptor(pointCloud->points),
+    index(3, adaptor, {10}) {
   nanort::BVHBuildOptions<float> options;
   options.cache_bbox = false;
   RowMatrixf vertices = pointCloud->points;
@@ -17,6 +21,24 @@ RayTraceCloud::RayTraceCloud(std::shared_ptr<geometry::PointCloud> pc, float& si
     std::cout << "Failed to initialize bounding volume hierarchy" << std::endl;
     exit(1);
   }
+  index.buildIndex();
+}
+
+Vector3f estimateNormal(const RowVector3f& queryPoint, const RowMatrixf& points, uint32_t* indices) {
+  Eigen::Matrix<float, Eigen::Dynamic, 3, Eigen::RowMajor> ps(FindClosest, 3);
+  for (uint32_t i=0; i < FindClosest; i++) {
+    ps.row(i) = points.row(indices[i]);
+  }
+
+  RowVector3f centroid = ps.rowwise().mean();
+
+  for (uint32_t i=0; i < FindClosest; i++) {
+    ps.row(i) = ps.row(i) - centroid;
+  }
+
+  auto svd = ps.transpose().jacobiSvd(Eigen::ComputeThinU | Eigen::ComputeThinV);
+  Vector3f normal = svd.matrixU().col(2);
+  return normal.normalized();
 }
 
 Intersection RayTraceCloud::traceRayIntersection(const Vector3f& origin, const Vector3f& direction) const {
@@ -39,9 +61,20 @@ Intersection RayTraceCloud::traceRayIntersection(const Vector3f& origin, const V
   bool hit = bvh.Traverse(ray, intersector, &intersection);
   if (hit) {
     unsigned int pointId = intersection.prim_id;
-    Vector3f position = pointCloud->points.row(pointId).transpose();
-    Vector3f hitPoint = origin + intersection.t * direction;
-    Vector3f normal = (hitPoint - position).normalized();
+    RowVector3f position = pointCloud->points.row(pointId);
+
+    nanoflann::KNNResultSet<float, uint32_t, uint32_t> resultSet(FindClosest);
+    resultSet.init(&closestIndices[0], &distances[0]);
+    float queryPoint[3] = { position[0], position[1], position[2] };
+    index.findNeighbors(resultSet, &queryPoint[0], nanoflann::SearchParams(10));
+    Vector3f normal = estimateNormal(position, pointCloud->points, &closestIndices[0]).normalized();
+
+    // If the normal is pointing in the same direction as the ray,
+    // the normal is on the wrong side and we should flip it.
+    if (direction.dot(normal) < 0.0) {
+      normal = -normal;
+    }
+
     return {true, position, normal};
   } else {
     return {false, Vector3f::Zero(), Vector3f::Zero()};
@@ -49,9 +82,27 @@ Intersection RayTraceCloud::traceRayIntersection(const Vector3f& origin, const V
 }
 
 std::optional<Vector3f> RayTraceCloud::traceRay(const Vector3f& origin, const Vector3f& direction) const {
-  Intersection its = traceRayIntersection(origin, direction);
-  if (its.hit) {
-    return its.point;
+  if (pointCloud == nullptr) return {};
+  nanort::Ray<float> ray;
+  ray.min_t = 0.0;
+  ray.max_t = 1e9f;
+  ray.org[0] = origin[0];
+  ray.org[1] = origin[1];
+  ray.org[2] = origin[2];
+
+  ray.dir[0] = direction[0];
+  ray.dir[1] = direction[1];
+  ray.dir[2] = direction[2];
+
+  float pointRadius = 0.005f * pointSize;
+  const float* points = &pointCloud->points.data()[0];
+  SphereIntersector<SphereIntersection> intersector(points, pointRadius);
+  SphereIntersection intersection;
+  bool hit = bvh.Traverse(ray, intersector, &intersection);
+  if (hit) {
+    unsigned int pointId = intersection.prim_id;
+    RowVector3f position = pointCloud->points.row(pointId);
+    return position.transpose();
   }
   return {};
 }

--- a/src/geometry/ray_trace_cloud.cc
+++ b/src/geometry/ray_trace_cloud.cc
@@ -1,4 +1,5 @@
 #include "geometry/ray_trace_cloud.h"
+#include <iostream>
 
 using namespace geometry;
 using namespace particle_tracing;
@@ -11,7 +12,11 @@ RayTraceCloud::RayTraceCloud(std::shared_ptr<geometry::PointCloud> pc, float& si
   RowMatrixf vertices = pointCloud->points;
   SphereGeometry sphereGeometry(vertices.data(), 0.01);
   SpherePred spherePredicate(vertices.data());
-  assert(bvh.Build(vertices.rows(), sphereGeometry, spherePredicate, options));
+  bool ret = bvh.Build(vertices.rows(), sphereGeometry, spherePredicate, options);
+  if (!ret) {
+    std::cout << "Failed to initialize bounding volume hierarchy" << std::endl;
+    exit(1);
+  }
 }
 
 Intersection RayTraceCloud::traceRayIntersection(const Vector3f& origin, const Vector3f& direction) const {


### PR DESCRIPTION
Properly computes the normal when placing bounding boxes in point clouds. 

Not the most elegant solution, but it works decently well and fast. Ideally the same acceleration data structure would be used for finding nearest neighbors in the point cloud as for ray tracing, but it didn't look like it would have been quite a bit more work to extend nanort to do nearest neighbor searches. 

In this case, a KDTree is created for the normal lookups. To estimate the normal, we find N closest points, fit a plane to the points and get the normal.