### PR TITLE
Default position + lookat

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "submodules/glfw"]
 	path = submodules/glfw
 	url = https://github.com/glfw/glfw
+[submodule "submodules/nanoflann"]
+	path = submodules/nanoflann
+	url = https://github.com/jlblancoc/nanoflann

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -80,7 +80,8 @@
         "numbers": "cpp",
         "semaphore": "cpp",
         "stop_token": "cpp",
-        "variant": "cpp"
+        "variant": "cpp",
+        "dense": "cpp"
     },
     "editor.defaultFormatter": "ms-vscode.cpptools"
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,11 @@ if (APPLE)
   set(EXTRA_LIBS ${COCOA_LIBRARY} ${CF_LIBRARY} ${IOKIT_LIBRARY})
 endif(APPLE)
 
-include_directories(include submodules/glfw/include ${eigen3_INCLUDE_DIRS} ${boost_INCLUDE_DIRS})
+include_directories(include
+  submodules/glfw/include
+  submodules/nanoflann/include
+  ${eigen3_INCLUDE_DIRS}
+  ${boost_INCLUDE_DIRS})
 include(cmake/shaders.cmake)
 
 include_directories("submodules/bgfx/bgfx/examples")

--- a/include/camera.h
+++ b/include/camera.h
@@ -6,9 +6,9 @@ using namespace Eigen;
 
 class SceneCamera {
 public:
+  Eigen::Matrix3f cameraMatrix;
   int imageWidth;
   int imageHeight;
-  Eigen::Matrix3f cameraMatrix;
 
   SceneCamera(const std::filesystem::path intrinsicsPath);
   SceneCamera(const Eigen::Matrix3f cameraMatrix, double width, double height);

--- a/include/controllers/point_cloud_view_controller.h
+++ b/include/controllers/point_cloud_view_controller.h
@@ -23,6 +23,7 @@
 #include "commands/bounding_box.h"
 #include "commands/rectangle.h"
 #include "utils/serialize.h"
+#include "views/controls/lookat.h"
 
 using namespace commands;
 namespace fs = std::filesystem;
@@ -35,9 +36,13 @@ private:
   SceneModel sceneModel;
   DatasetMetadata datasetMetadata;
 
+  Vector3f pclMean;
+  float pclScale;
+
   ViewContext3D viewContext;
   views::AnnotationView annotationView;
   views::PointCloudView pointCloudView;
+  views::controls::LookatControl lookatControl;
 
   // Tool views.
   views::AddKeypointView addKeypointView;
@@ -55,7 +60,7 @@ public:
   PointCloudViewController(fs::path folder);
   void viewWillAppear(const views::Rect& r) override;
 
-  void render() const;
+  void render(InputModifier mod) const;
   void refresh();
 
   bool leftButtonDown(double x, double y, InputModifier mod);

--- a/include/controllers/studio_view_controller.h
+++ b/include/controllers/studio_view_controller.h
@@ -51,7 +51,7 @@ public:
   StudioViewController(fs::path datasetPath);
   void viewWillAppear(const views::Rect& r) override;
 
-  void render() const;
+  void render(InputModifier mod) const;
   void refresh();
 
   bool leftButtonDown(double x, double y, InputModifier mod);

--- a/include/geometry/point_cloud.h
+++ b/include/geometry/point_cloud.h
@@ -12,5 +12,6 @@ public:
   RowMatrixu8 colors;
   PointCloud(const std::string& filepath);
   Eigen::RowVector3f getMean() const;
+  Eigen::RowVector3f getStd() const;
 };
 } // namespace geometry

--- a/include/geometry/ray_trace_cloud.h
+++ b/include/geometry/ray_trace_cloud.h
@@ -1,17 +1,45 @@
 #include <memory>
 #include <optional>
+#include <nanoflann.hpp>
 #define NANORT_ENABLE_PARALLEL_BUILD 1
 #include "3rdparty/nanort.h"
 #include "3rdparty/particle_tracing.h"
 #include "geometry/ray_trace_mesh.h"
 #include "geometry/point_cloud.h"
 
+#include <iostream>
 namespace geometry {
+
+using RowMatrixf = Eigen::Matrix<float, Eigen::Dynamic, 3, Eigen::RowMajor>;
+
+template <typename T>
+struct PCAdaptor {
+  const RowMatrixf& pointCloud;
+  PCAdaptor(const RowMatrixf& pc) : pointCloud(pc) {}
+
+  using coord_t = T;
+  inline uint32_t kdtree_get_point_count() const { return pointCloud.rows(); };
+  inline T kdtree_get_pt(const uint32_t idx, const uint32_t dim) const {
+    RowVector3f vec = pointCloud.row(idx);
+    if (dim == 0) return vec[0];
+    else if(dim == 1) return vec[1];
+    else return vec[2];
+  }
+  template <class BBOX>
+  bool kdtree_get_bbox(BBOX& ) const { return false; }
+};
+
+using KDTree = nanoflann::KDTreeSingleIndexAdaptor<
+  nanoflann::L2_Simple_Adaptor<float, PCAdaptor<float>, float>,
+  PCAdaptor<float>, 3>;
+
 class RayTraceCloud {
 private:
   std::shared_ptr<PointCloud> pointCloud;
   nanort::BVHAccel<float> bvh;
   float& pointSize;
+  PCAdaptor<float> adaptor;
+  KDTree index;
 public:
   RayTraceCloud(std::shared_ptr<geometry::PointCloud> pc, float& pointCloudPointSize);
   std::optional<Vector3f> traceRay(const Vector3f& origin, const Vector3f& direction) const;

--- a/include/studio.h
+++ b/include/studio.h
@@ -20,12 +20,11 @@ public:
   ViewController viewController;
   InputModifier inputModifier = ModNone;
 
-  Studio(const std::string& folder) : GLFWApp("Studio", 1200, 800), viewController(folder) {
+  Studio(const std::string& folder) : GLFWApp("Stray 3D Annotation Tool", 1200, 800), viewController(folder) {
     glfwSetMouseButtonCallback(window, [](GLFWwindow* window, int button, int action, int mods) {
       double x, y;
       glfwGetCursorPos(window, &x, &y);
       Studio* w = (Studio*)glfwGetWindowUserPointer(window);
-      w->setInputModifier(mods);
       if (button == GLFW_MOUSE_BUTTON_LEFT && action == GLFW_PRESS) {
         w->leftButtonDown(x, y);
       } else if (button == GLFW_MOUSE_BUTTON_LEFT && action == GLFW_RELEASE) {
@@ -49,7 +48,7 @@ public:
 
     glfwSetKeyCallback(window, [](GLFWwindow* window, int key, int scancode, int action, int mods) {
       Studio* w = (Studio*)glfwGetWindowUserPointer(window);
-      w->setInputModifier(mods);
+      w->setInputModifier(key);
       if (action == GLFW_PRESS) {
         if ((CommandModifier == mods) && (GLFW_KEY_S == key)) {
           w->viewController.save();
@@ -70,19 +69,18 @@ public:
   void leftButtonDown(double x, double y) {
     viewController.leftButtonDown(x, y, inputModifier);
   }
-  void setInputModifier(int mods) {
-    inputModifier = ModNone;
-    if (mods & CommandModifier) {
-      inputModifier = inputModifier | ModCommand; // Only set bits of inputModifier
+  void setInputModifier(int key) {
+    if (key == GLFW_KEY_LEFT_CONTROL || key == GLFW_KEY_LEFT_SUPER) {
+      inputModifier = inputModifier ^ ModCommand;
     }
-    if (mods & ShiftModifier) {
-      inputModifier = inputModifier | ModShift;
+    if (key == GLFW_KEY_LEFT_SHIFT) {
+      inputModifier = inputModifier ^ ModShift;
     }
-    if (mods & AltModifier) {
-      inputModifier = inputModifier | ModAlt;
+    if (key == GLFW_KEY_LEFT_ALT) {
+      inputModifier = inputModifier ^ ModAlt;
     }
-    if (mods & CtrlModifier) {
-      inputModifier = inputModifier | ModCtrl;
+    if (key == GLFW_KEY_LEFT_CONTROL) {
+      inputModifier = inputModifier ^ ModCtrl;
     }
   }
   void leftButtonUp(double x, double y) {
@@ -100,7 +98,7 @@ public:
     viewController.resize(rect);
   }
   bool update() const {
-    viewController.render();
+    viewController.render(inputModifier);
 
     bgfx::frame();
 

--- a/include/view_context_3d.h
+++ b/include/view_context_3d.h
@@ -19,5 +19,4 @@ public:
 
   Vector3f rayWorld() const;
   std::optional<Vector3f> pointingAt;
-  std::optional<Vector3f> pointingAtNormal;
 };

--- a/include/views/controls/lookat.h
+++ b/include/views/controls/lookat.h
@@ -1,0 +1,31 @@
+#pragma once
+#include <optional>
+#include <functional>
+#include <memory>
+#include <bgfx/bgfx.h>
+#include <eigen3/Eigen/Geometry>
+#include "geometry/mesh.h"
+#include "geometry/ray_trace_mesh.h"
+#include "views/mesh_view.h"
+#include "views/controls/control.h"
+#include "view_context_3d.h"
+
+namespace views::controls {
+
+class LookatControl : public views::controls::Control {
+private:
+  const Vector4f lightDir = Vector4f(0.0, 1.0, -1.0, 1.0);
+  views::MeshDrawable sphereDrawable;
+  // views::MeshDrawable sphereDrawable;
+  //  Rendering.
+  bgfx::ProgramHandle program;
+  bgfx::UniformHandle u_color, u_lightDir;
+  int activeAxis = -1;
+
+public:
+  LookatControl(int viewId);
+  ~LookatControl(){};
+  void render(const ViewContext3D& context) const;
+};
+
+} // namespace views::controls

--- a/src/camera.cc
+++ b/src/camera.cc
@@ -126,13 +126,10 @@ void Camera::rotateAroundTarget(const Quaternionf& q) {
 }
 
 void Camera::zoom(float d) {
-  float norm = (getPosition() - lookat).norm();
-  if (norm > d) {
-    Affine3f newViewMatrix;
-    position += getForwardVector() * d;
-    Quaternionf q = getOrientation().conjugate();
-    newViewMatrix.linear() = q.toRotationMatrix();
-    newViewMatrix.translation() = -(viewMatrix.linear() * getPosition());
-    setViewMatrix(newViewMatrix);
-  }
+  Affine3f newViewMatrix;
+  position += getForwardVector() * d;
+  Quaternionf q = getOrientation().conjugate();
+  newViewMatrix.linear() = q.toRotationMatrix();
+  newViewMatrix.translation() = -(viewMatrix.linear() * getPosition());
+  setViewMatrix(newViewMatrix);
 }

--- a/src/controllers/point_cloud_view_controller.cc
+++ b/src/controllers/point_cloud_view_controller.cc
@@ -188,10 +188,8 @@ void PointCloudViewController::updateViewContext(double x, double y, InputModifi
   auto intersection = sceneModel.traceRayIntersection(viewContext.camera.getPosition(), rayDirection);
   if (intersection.hit) {
     viewContext.pointingAt = intersection.point;
-    viewContext.pointingAtNormal = intersection.normal;
   } else {
     viewContext.pointingAt = {};
-    viewContext.pointingAtNormal = {};
   }
 }
 

--- a/src/controllers/point_cloud_view_controller.cc
+++ b/src/controllers/point_cloud_view_controller.cc
@@ -35,7 +35,7 @@ void PointCloudViewController::viewWillAppear(const views::Rect& rect) {
   pclScale = sceneModel.getPointCloud()->getStd().norm();
 
   viewContext.camera.reset(pclMean, pclMean);
-  viewContext.camera.zoom(-5 * pclScale);
+  viewContext.camera.zoom(-5 * pclScale); // TODO: Is there a better strategy? Seems to be fine for bot large and small scenes
 
   viewContext.width = rect.width;
   viewContext.height = rect.height - views::StatusBarHeight;
@@ -120,8 +120,8 @@ bool PointCloudViewController::mouseMoved(double x, double y, InputModifier mod)
 
   if (dragging) {
     moved = true;
-    float diffX = float(x - prevX) * pclScale / 10;
-    float diffY = float(y - prevY) * pclScale / 10;
+    float diffX = float(x - prevX); // TODO: scale according to cloud size
+    float diffY = float(y - prevY); // TODO: scale according to cloud size
     if (mod & ModCommand) {
       viewContext.camera.translate(Vector3f(-diffX / float(viewContext.width), diffY / float(viewContext.height), 0));
     } else {
@@ -137,7 +137,7 @@ bool PointCloudViewController::mouseMoved(double x, double y, InputModifier mod)
 }
 
 bool PointCloudViewController::scroll(double xoffset, double yoffset, InputModifier mod) {
-  float diff = yoffset * pclScale / 10;
+  float diff = yoffset * pclScale / 5; // TODO: is there a better heuristic?
   if (mod & ModCommand) {
     Vector3f fwd(0.0, 0.0, 1.0);
     viewContext.camera.translate(fwd * diff);

--- a/src/controllers/studio_view_controller.cc
+++ b/src/controllers/studio_view_controller.cc
@@ -178,6 +178,7 @@ bool StudioViewController::keypress(char character, const InputModifier mod) {
   } else if (mod == ModShift && character == '2') {
     pointCloudView.loadPointCloud();
     sceneModel.activeView = active_view::PointCloudView;
+    return true;
   } else if (character == 'K') {
     sceneModel.activeToolId = AddKeypointToolId;
     return true;

--- a/src/controllers/studio_view_controller.cc
+++ b/src/controllers/studio_view_controller.cc
@@ -62,7 +62,7 @@ void StudioViewController::refresh() {
   moveToolView.refresh();
 }
 
-void StudioViewController::render() const {
+void StudioViewController::render(InputModifier mod) const {
   bgfx::setViewRect(viewId, 0, 0, viewContext.width, viewContext.height);
   annotationView.render(viewContext);
 

--- a/src/controllers/studio_view_controller.cc
+++ b/src/controllers/studio_view_controller.cc
@@ -224,13 +224,11 @@ void StudioViewController::updateViewContext(double x, double y, InputModifier m
 
   const Vector3f& rayDirection = viewContext.camera.computeRayWorld(viewContext.width, viewContext.height,
                                                                     viewContext.mousePositionX, viewContext.mousePositionY);
-  auto intersection = sceneModel.traceRayIntersection(viewContext.camera.getPosition(), rayDirection);
-  if (intersection.hit) {
-    viewContext.pointingAt = intersection.point;
-    viewContext.pointingAtNormal = intersection.normal;
+  auto point = sceneModel.traceRay(viewContext.camera.getPosition(), rayDirection);
+  if (point.has_value()) {
+    viewContext.pointingAt = point;
   } else {
     viewContext.pointingAt = {};
-    viewContext.pointingAtNormal = {};
   }
 }
 

--- a/src/geometry/point_cloud.cc
+++ b/src/geometry/point_cloud.cc
@@ -22,4 +22,17 @@ Eigen::RowVector3f PointCloud::getMean() const {
   return mean;
 }
 
+Eigen::RowVector3f PointCloud::getStd() const {
+  Eigen::VectorXf x = points.col(0);
+  Eigen::VectorXf y = points.col(1);
+  Eigen::VectorXf z = points.col(2);
+
+  float std_x = std::sqrt(((x - x.mean() * Eigen::VectorXf::Ones(x.size())).array().square().sum() / (x.size() - 1)));
+  float std_y = std::sqrt(((y - y.mean() * Eigen::VectorXf::Ones(y.size())).array().square().sum() / (y.size() - 1)));
+  float std_z = std::sqrt(((z - z.mean() * Eigen::VectorXf::Ones(z.size())).array().square().sum() / (z.size() - 1)));
+
+  Eigen::RowVector3f std(std_x, std_y, std_z);
+  return std;
+}
+
 } // namespace geometry

--- a/src/geometry/ray_trace_cloud.cc
+++ b/src/geometry/ray_trace_cloud.cc
@@ -9,8 +9,8 @@ uint32_t closestIndices[FindClosest];
 float distances[FindClosest];
 
 RayTraceCloud::RayTraceCloud(std::shared_ptr<geometry::PointCloud> pc, float& size) : pointCloud(pc), pointSize(size),
-    adaptor(pointCloud->points),
-    index(3, adaptor, {10}) {
+                                                                                      adaptor(pointCloud->points),
+                                                                                      index(3, adaptor, {10}) {
   nanort::BVHBuildOptions<float> options;
   options.cache_bbox = false;
   RowMatrixf vertices = pointCloud->points;
@@ -26,13 +26,13 @@ RayTraceCloud::RayTraceCloud(std::shared_ptr<geometry::PointCloud> pc, float& si
 
 Vector3f estimateNormal(const RowVector3f& queryPoint, const RowMatrixf& points, uint32_t* indices) {
   Eigen::Matrix<float, Eigen::Dynamic, 3, Eigen::RowMajor> ps(FindClosest, 3);
-  for (uint32_t i=0; i < FindClosest; i++) {
+  for (uint32_t i = 0; i < FindClosest; i++) {
     ps.row(i) = points.row(indices[i]);
   }
 
-  RowVector3f centroid = ps.rowwise().mean();
+  RowVector3f centroid = ps.colwise().mean();
 
-  for (uint32_t i=0; i < FindClosest; i++) {
+  for (uint32_t i = 0; i < FindClosest; i++) {
     ps.row(i) = ps.row(i) - centroid;
   }
 
@@ -65,7 +65,7 @@ Intersection RayTraceCloud::traceRayIntersection(const Vector3f& origin, const V
 
     nanoflann::KNNResultSet<float, uint32_t, uint32_t> resultSet(FindClosest);
     resultSet.init(&closestIndices[0], &distances[0]);
-    float queryPoint[3] = { position[0], position[1], position[2] };
+    float queryPoint[3] = {position[0], position[1], position[2]};
     index.findNeighbors(resultSet, &queryPoint[0], nanoflann::SearchParams(10));
     Vector3f normal = estimateNormal(position, pointCloud->points, &closestIndices[0]).normalized();
 

--- a/src/geometry/ray_trace_cloud.cc
+++ b/src/geometry/ray_trace_cloud.cc
@@ -4,9 +4,13 @@
 using namespace geometry;
 using namespace particle_tracing;
 
-using RowMatrixf = Eigen::Matrix<float, Eigen::Dynamic, 3, Eigen::RowMajor>;
+const uint32_t FindClosest = 50;
+uint32_t closestIndices[FindClosest];
+float distances[FindClosest];
 
-RayTraceCloud::RayTraceCloud(std::shared_ptr<geometry::PointCloud> pc, float& size) : pointCloud(pc), pointSize(size) {
+RayTraceCloud::RayTraceCloud(std::shared_ptr<geometry::PointCloud> pc, float& size) : pointCloud(pc), pointSize(size),
+    adaptor(pointCloud->points),
+    index(3, adaptor, {10}) {
   nanort::BVHBuildOptions<float> options;
   options.cache_bbox = false;
   RowMatrixf vertices = pointCloud->points;
@@ -17,6 +21,24 @@ RayTraceCloud::RayTraceCloud(std::shared_ptr<geometry::PointCloud> pc, float& si
     std::cout << "Failed to initialize bounding volume hierarchy" << std::endl;
     exit(1);
   }
+  index.buildIndex();
+}
+
+Vector3f estimateNormal(const RowVector3f& queryPoint, const RowMatrixf& points, uint32_t* indices) {
+  Eigen::Matrix<float, Eigen::Dynamic, 3, Eigen::RowMajor> ps(FindClosest, 3);
+  for (uint32_t i=0; i < FindClosest; i++) {
+    ps.row(i) = points.row(indices[i]);
+  }
+
+  RowVector3f centroid = ps.rowwise().mean();
+
+  for (uint32_t i=0; i < FindClosest; i++) {
+    ps.row(i) = ps.row(i) - centroid;
+  }
+
+  auto svd = ps.transpose().jacobiSvd(Eigen::ComputeThinU | Eigen::ComputeThinV);
+  Vector3f normal = svd.matrixU().col(2);
+  return normal.normalized();
 }
 
 Intersection RayTraceCloud::traceRayIntersection(const Vector3f& origin, const Vector3f& direction) const {
@@ -39,9 +61,20 @@ Intersection RayTraceCloud::traceRayIntersection(const Vector3f& origin, const V
   bool hit = bvh.Traverse(ray, intersector, &intersection);
   if (hit) {
     unsigned int pointId = intersection.prim_id;
-    Vector3f position = pointCloud->points.row(pointId).transpose();
-    Vector3f hitPoint = origin + intersection.t * direction;
-    Vector3f normal = (hitPoint - position).normalized();
+    RowVector3f position = pointCloud->points.row(pointId);
+
+    nanoflann::KNNResultSet<float, uint32_t, uint32_t> resultSet(FindClosest);
+    resultSet.init(&closestIndices[0], &distances[0]);
+    float queryPoint[3] = { position[0], position[1], position[2] };
+    index.findNeighbors(resultSet, &queryPoint[0], nanoflann::SearchParams(10));
+    Vector3f normal = estimateNormal(position, pointCloud->points, &closestIndices[0]).normalized();
+
+    // If the normal is pointing in the same direction as the ray,
+    // the normal is on the wrong side and we should flip it.
+    if (direction.dot(normal) < 0.0) {
+      normal = -normal;
+    }
+
     return {true, position, normal};
   } else {
     return {false, Vector3f::Zero(), Vector3f::Zero()};
@@ -49,9 +82,27 @@ Intersection RayTraceCloud::traceRayIntersection(const Vector3f& origin, const V
 }
 
 std::optional<Vector3f> RayTraceCloud::traceRay(const Vector3f& origin, const Vector3f& direction) const {
-  Intersection its = traceRayIntersection(origin, direction);
-  if (its.hit) {
-    return its.point;
+  if (pointCloud == nullptr) return {};
+  nanort::Ray<float> ray;
+  ray.min_t = 0.0;
+  ray.max_t = 1e9f;
+  ray.org[0] = origin[0];
+  ray.org[1] = origin[1];
+  ray.org[2] = origin[2];
+
+  ray.dir[0] = direction[0];
+  ray.dir[1] = direction[1];
+  ray.dir[2] = direction[2];
+
+  float pointRadius = 0.005f * pointSize;
+  const float* points = &pointCloud->points.data()[0];
+  SphereIntersector<SphereIntersection> intersector(points, pointRadius);
+  SphereIntersection intersection;
+  bool hit = bvh.Traverse(ray, intersector, &intersection);
+  if (hit) {
+    unsigned int pointId = intersection.prim_id;
+    RowVector3f position = pointCloud->points.row(pointId);
+    return position.transpose();
   }
   return {};
 }

--- a/src/geometry/ray_trace_cloud.cc
+++ b/src/geometry/ray_trace_cloud.cc
@@ -1,4 +1,5 @@
 #include "geometry/ray_trace_cloud.h"
+#include <iostream>
 
 using namespace geometry;
 using namespace particle_tracing;
@@ -11,7 +12,11 @@ RayTraceCloud::RayTraceCloud(std::shared_ptr<geometry::PointCloud> pc, float& si
   RowMatrixf vertices = pointCloud->points;
   SphereGeometry sphereGeometry(vertices.data(), 0.01);
   SpherePred spherePredicate(vertices.data());
-  assert(bvh.Build(vertices.rows(), sphereGeometry, spherePredicate, options));
+  bool ret = bvh.Build(vertices.rows(), sphereGeometry, spherePredicate, options);
+  if (!ret) {
+    std::cout << "Failed to initialize bounding volume hierarchy" << std::endl;
+    exit(1);
+  }
 }
 
 Intersection RayTraceCloud::traceRayIntersection(const Vector3f& origin, const Vector3f& direction) const {

--- a/src/views/controls/lookat.cc
+++ b/src/views/controls/lookat.cc
@@ -1,0 +1,25 @@
+#include <bx/math.h>
+#include "views/controls/lookat.h"
+#include "views/view.h"
+#include "geometry/mesh.h"
+#include "views/mesh_view.h"
+#include "shader_utils.h"
+#include "views/controls/control.h"
+#include "shader_utils.h"
+#include "geometry/mesh.h"
+#include "asset_utils.h"
+#include <iostream>
+
+namespace views::controls {
+
+LookatControl::LookatControl(int viewId) : views::controls::Control(viewId), sphereDrawable(std::make_shared<geometry::Sphere>(Matrix4f::Identity(), 0.05), viewId) {
+}
+
+void LookatControl::render(const ViewContext3D& context) const {
+  Matrix4f T = Matrix4f::Identity();
+  T.block<3, 1>(0, 3) = context.camera.getLookat();
+  const Vector4f color(1.0f, 0.0f, 0.0f, 1.0f);
+  sphereDrawable.render(context, T, color);
+}
+
+} // namespace views::controls

--- a/src/views/point_view.cc
+++ b/src/views/point_view.cc
@@ -48,7 +48,7 @@ void PointView::render(const ViewContext3D& context) const {
 
   const auto camera = context.camera;
   float proj[16];
-  bx::mtxProj(proj, camera.fov, float(context.width) / float(context.height), 0.1f, 25.0f, bgfx::getCaps()->homogeneousDepth, bx::Handness::Right);
+  bx::mtxProj(proj, camera.fov, float(context.width) / float(context.height), 0.1f, 1000.0f, bgfx::getCaps()->homogeneousDepth, bx::Handness::Right);
   Eigen::Matrix4f viewMatrix = camera.getViewMatrix().matrix();
   bgfx::setViewTransform(viewId, viewMatrix.data(), proj);
 

--- a/src/views/view.cc
+++ b/src/views/view.cc
@@ -11,7 +11,7 @@ bool View::hit(const ViewContext3D& ctx) const {
 void View3D::setCameraTransform(const ViewContext3D& context) const {
   const auto camera = context.camera;
   float proj[16];
-  bx::mtxProj(proj, camera.fov, float(context.width) / float(context.height), 0.1f, 25.0f, bgfx::getCaps()->homogeneousDepth, bx::Handness::Right);
+  bx::mtxProj(proj, camera.fov, float(context.width) / float(context.height), 0.1f, 1000.0f, bgfx::getCaps()->homogeneousDepth, bx::Handness::Right);
   bgfx::setViewTransform(viewId, camera.getViewMatrix().data(), proj);
 }
 


### PR DESCRIPTION

https://user-images.githubusercontent.com/4254623/160874763-5a3c5c48-685c-4d5d-9fdd-c582579ab0a7.mp4

Initially points the camera to the mean of the cloud. Also calculates the std of the points in order to determine a scale factor for the cloud. Did not yet find a bulletproof heuristic that would work super well for small and large scenes. With larger scenes there also seems to be a bug when alternating between translating and rotating around a target.

Also renders the lookat point when `citrl/cmd` is held down. This should probably be evolved into something more sophisticated e.g. what meshlab does.