### PR TITLE
Switching clouds

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The properties are:
 7. The executable is called `pointcloud`, it can be executed with `./pointcloud <path-to-pointcloud>`. You can find an example `cloud.ply` point cloud  from [here](https://stray-data.nyc3.digitaloceanspaces.com/tutorials/cloud.ply). `<path-to-pointcloud>` should then specify the absolute path to the downloaded file.
 ## Usage
 
-Run `./pointcloud <path-to-pointcloud>` to open a point cloud in the viewer. Currently only `.ply` point clouds are supported. Annotations are saved into a file of with the same filename but a `.json` file extension.
+Run `./pointcloud <path-to-pointcloud>` to open a point cloud in the viewer. Currently only `.ply` point clouds are supported. Annotations are saved into a file of with the same filename but a `.json` file extension. In the point cloud annotation tool, you can move to the next point cloud in the same directory as `<path-to-pointcloud>` using `tab`.
 
 Stray scenes can be opened with the `./studio` program running `./studio <path-to-scene>`. An example `cloud.ply` point cloud can be downloaded from [here](https://stray-data.nyc3.digitaloceanspaces.com/tutorials/cloud.ply).
 
@@ -67,7 +67,6 @@ The keyboard shortcuts are:
 - `r` switches to the rectangle tool.
 - `v` switches to the move tool.
 
-In the point cloud annotation tool, you can move to the next point cloud in the dataset using `tab`.
 
 ## Running tests
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The properties are:
 1. Install Homebrew: https://brew.sh/
 2. Run `brew update && brew install cmake libomp eigen boost git-lfs pkg-config`
 
-### Install Dependensies - Linux
+### Install Dependencies - Linux
 1. RUN `sudo apt install libeigen3-dev libglfw3-dev libomp-dev libxinerama-dev libxcursor-dev libxi-dev git-lfs cmake libboost-all-dev`
 
 ### Build and install the annotation tool
@@ -53,7 +53,7 @@ The properties are:
 4. Create a build directory with `mkdir build`
 5. Pull `git-lfs` objects (helper meshes etc) with `git lfs install && git lfs pull`
 6. To build the project run `cd build && cmake .. && make -j8` (`-j8` specifies the number of parallel jobs, for a fewer jobs use a lower number (than `8`))
-7. The executable is called `pointcloud`, it can be executed with `./pointcloud <path-to-pointcloud>`. You can find an example `cloud.ply` point cloud  from [here](https://stray-data.nyc3.digitaloceanspaces.com/tutorials/cloud.ply). `<path-to-pointcloud>` should then specify the absolute path to the downloaded file. 
+7. The executable is called `pointcloud`, it can be executed with `./pointcloud <path-to-pointcloud>`. You can find an example `cloud.ply` point cloud  from [here](https://stray-data.nyc3.digitaloceanspaces.com/tutorials/cloud.ply). `<path-to-pointcloud>` should then specify the absolute path to the downloaded file.
 ## Usage
 
 Run `./pointcloud <path-to-pointcloud>` to open a point cloud in the viewer. Currently only `.ply` point clouds are supported. Annotations are saved into a file of with the same filename but a `.json` file extension.
@@ -66,6 +66,8 @@ The keyboard shortcuts are:
 - `b` switches to the bounding box tool.
 - `r` switches to the rectangle tool.
 - `v` switches to the move tool.
+
+In the point cloud annotation tool, you can move to the next point cloud in the dataset using `tab`.
 
 ## Running tests
 

--- a/include/controllers/point_cloud_view_controller.h
+++ b/include/controllers/point_cloud_view_controller.h
@@ -25,6 +25,7 @@
 #include "utils/serialize.h"
 #include "views/controls/lookat.h"
 #include "camera/camera_controls.h"
+#include "model/point_cloud_dataset.h"
 
 using namespace commands;
 namespace fs = std::filesystem;
@@ -32,8 +33,10 @@ class PointCloudViewController : public controllers::Controller {
 private:
   int viewId;
   Timeline timeline;
-  fs::path dataPath;
+
+  fs::path pointCloudPath;
   fs::path annotationPath;
+  model::PointCloudDataset dataset;
   SceneModel sceneModel;
   DatasetMetadata datasetMetadata;
 
@@ -79,4 +82,5 @@ private:
   views::View3D& getActiveToolView();
   views::Rect statusBarRect() const;
   void updateViewContext(double x, double y, InputModifier mod);
+  void nextPointCloud();
 };

--- a/include/controllers/point_cloud_view_controller.h
+++ b/include/controllers/point_cloud_view_controller.h
@@ -34,7 +34,6 @@ private:
   int viewId;
   Timeline timeline;
 
-  fs::path pointCloudPath;
   fs::path annotationPath;
   model::PointCloudDataset dataset;
   SceneModel sceneModel;

--- a/include/controllers/studio_view_controller.h
+++ b/include/controllers/studio_view_controller.h
@@ -26,6 +26,8 @@ private:
   SceneModel sceneModel;
   SceneCamera sceneCamera;
   fs::path datasetPath;
+  fs::path pointCloudPath;
+
   DatasetMetadata datasetMetadata;
   Timeline timeline;
 
@@ -70,4 +72,5 @@ private:
   views::Rect previewRect() const;
   views::Rect statusBarRect() const;
   void updateViewContext(double x, double y, InputModifier mod);
+  void loadPointCloud();
 };

--- a/include/model/point_cloud_dataset.h
+++ b/include/model/point_cloud_dataset.h
@@ -1,4 +1,6 @@
 #include <filesystem>
+#include <memory>
+#include "geometry/point_cloud.h"
 
 namespace fs = std::filesystem;
 
@@ -7,6 +9,7 @@ class PointCloudDataset {
 private:
   fs::path path;
   fs::path currentPointCloud;
+  std::shared_ptr<geometry::PointCloud> currentCloud;
   std::vector<fs::path> pointClouds;
   int currentIndex = -1;
 public:
@@ -17,11 +20,16 @@ public:
       return pc == current;
     });
     currentIndex = it - pointClouds.begin();
+    currentCloud = std::make_shared<geometry::PointCloud>(currentPointCloud.string());
   }
 
-  fs::path next() {
+  std::shared_ptr<geometry::PointCloud> getCurrentCloud() const { return currentCloud; }
+
+  fs::path currentPath() const { return currentPointCloud; }
+  std::shared_ptr<geometry::PointCloud> next() {
     currentIndex = (currentIndex + 1) % int(pointClouds.size());
-    return pointClouds[currentIndex];
+    currentPointCloud = pointClouds[currentIndex];
+    return std::make_shared<geometry::PointCloud>(currentPointCloud.string());
   }
 
 private:

--- a/include/model/point_cloud_dataset.h
+++ b/include/model/point_cloud_dataset.h
@@ -17,57 +17,13 @@ private:
   std::vector<fs::path> pointClouds;
   int currentIndex = -1;
 public:
-  PointCloudDataset(fs::path current) : path(current.parent_path()), currentPointCloud(current) {
-    indexPointClouds();
-
-    auto it = find_if(pointClouds.begin(), pointClouds.end(), [&](const fs::path pc) {
-      return pc == current;
-    });
-    currentIndex = it - pointClouds.begin();
-    currentCloud = fetchPointCloud(currentPointCloud);
-    nextCloud = fetchPointCloud(nextPath());
-  }
-
-  const std::shared_future<PointCloudPtr>& getCurrentCloud() const {
-    return currentCloud;
-  }
-
-  fs::path currentPath() const { return currentPointCloud; }
-  fs::path nextPath() const {
-    int nextIndex = (currentIndex + 1) % int(pointClouds.size());
-    return pointClouds[nextIndex];
-  }
-
-  std::shared_future<PointCloudPtr> next() {
-    currentIndex = (currentIndex + 1) % int(pointClouds.size());
-    currentPointCloud = pointClouds[currentIndex];
-    currentCloud = nextCloud;
-    nextCloud = fetchPointCloud(nextPath());
-    return currentCloud;
-  }
+  PointCloudDataset(fs::path current);
+  const std::shared_future<PointCloudPtr>& getCurrentCloud() const;
+  fs::path currentPath() const;
+  fs::path nextPath() const;
+  std::shared_future<PointCloudPtr> next();
 private:
-  void indexPointClouds() {
-    for (auto& p : fs::directory_iterator(path)) {
-      fs::path file = p.path();
-      std::string extension = file.extension().string();
-      if (extension == ".ply") {
-        pointClouds.push_back(file);
-      }
-    }
-  }
-
-  std::shared_future<PointCloudPtr> fetchPointCloud(fs::path pcPath) {
-    auto path = nextPath();
-    std::promise<PointCloudPtr> promise;
-    std::shared_future<PointCloudPtr> theFuture = promise.get_future();
-    auto getFunction = [&, theFuture]() -> PointCloudPtr {
-      PointCloudPtr ptr = std::make_shared<geometry::PointCloud>(pcPath.string());
-      promise.set_value(ptr);
-      theFuture.wait();
-      return ptr;
-    };
-    auto result = std::async(std::launch::async, getFunction);
-    return theFuture;
-  }
+  void indexPointClouds();
+  std::shared_future<PointCloudPtr> fetchPointCloud(fs::path pcPath);
 };
 }

--- a/include/model/point_cloud_dataset.h
+++ b/include/model/point_cloud_dataset.h
@@ -1,0 +1,38 @@
+#include <filesystem>
+
+namespace fs = std::filesystem;
+
+namespace model {
+class PointCloudDataset {
+private:
+  fs::path path;
+  fs::path currentPointCloud;
+  std::vector<fs::path> pointClouds;
+  int currentIndex = -1;
+public:
+  PointCloudDataset(fs::path current) : path(current.parent_path()), currentPointCloud(current) {
+    indexPointClouds();
+
+    auto it = find_if(pointClouds.begin(), pointClouds.end(), [&](const fs::path pc) {
+      return pc == current;
+    });
+    currentIndex = it - pointClouds.begin();
+  }
+
+  fs::path next() {
+    currentIndex = (currentIndex + 1) % int(pointClouds.size());
+    return pointClouds[currentIndex];
+  }
+
+private:
+  void indexPointClouds() {
+    for (auto& p : fs::directory_iterator(path)) {
+      fs::path file = p.path();
+      std::string extension = file.extension().string();
+      if (extension == ".ply") {
+        pointClouds.push_back(file);
+      }
+    }
+  }
+};
+}

--- a/include/scene_model.h
+++ b/include/scene_model.h
@@ -79,13 +79,17 @@ public:
 
   SceneModel(std::optional<std::string> meshPath = std::nullopt); // Could be aligned with how point clouds are handled i.e. set the path and load the mesh after initialization, needs small refactoring in mesh_view
 
-  void setPointCloudPath(std::string path) { pointCloudPath = path; }
+  void setPointCloudPath(std::string path);
 
   std::shared_ptr<geometry::TriangleMesh> getMesh();
   std::shared_ptr<geometry::PointCloud> getPointCloud();
   std::optional<Vector3f> traceRay(const Vector3f& origin, const Vector3f& direction);
   geometry::Intersection traceRayIntersection(const Vector3f& origin, const Vector3f& direction);
 
+  /*
+   * Called when changing the scene.
+   */
+  void reset();
   // Keypoints
   const std::vector<Keypoint>& getKeypoints() const { return keypoints; };
   Keypoint addKeypoint(const Vector3f& kp);

--- a/include/scene_model.h
+++ b/include/scene_model.h
@@ -79,7 +79,7 @@ public:
 
   SceneModel(std::optional<std::string> meshPath = std::nullopt); // Could be aligned with how point clouds are handled i.e. set the path and load the mesh after initialization, needs small refactoring in mesh_view
 
-  void setPointCloudPath(std::string path);
+  void setPointCloud(std::shared_ptr<geometry::PointCloud> pc);
 
   std::shared_ptr<geometry::TriangleMesh> getMesh();
   std::shared_ptr<geometry::PointCloud> getPointCloud();
@@ -118,7 +118,6 @@ public:
   void load(fs::path annotationPath);
 
   void loadMesh();
-  void loadPointCloud();
 };
 
 #endif

--- a/include/timeline.h
+++ b/include/timeline.h
@@ -27,6 +27,7 @@ public:
   Timeline(Timeline const& other) = delete;
 
   void load(fs::path annotationPath) {
+    commandStack.clear();
     if (!std::filesystem::exists(annotationPath))
       return;
     std::ifstream file(annotationPath.string());

--- a/include/views/point_cloud_view.h
+++ b/include/views/point_cloud_view.h
@@ -28,5 +28,9 @@ public:
   void changeSize(float diff);
   void packVertexData();
   void render(const ViewContext3D& context) const;
+  /*
+   * Called when the point cloud has changed.
+   */
+  void reload();
 };
 }

--- a/src/controllers/point_cloud_view_controller.cc
+++ b/src/controllers/point_cloud_view_controller.cc
@@ -11,10 +11,9 @@ namespace fs = std::filesystem;
 
 PointCloudViewController::PointCloudViewController(fs::path pcPath) : viewId(IdFactory::getInstance().getId()),
                                                                               timeline(sceneModel),
-                                                                              pointCloudPath(pcPath),
                                                                               dataset(pcPath),
                                                                               sceneModel(),
-                                                                              datasetMetadata(utils::dataset::getDatasetMetadata(pointCloudPath.parent_path() / "metadata.json")),
+                                                                              datasetMetadata(utils::dataset::getDatasetMetadata(pcPath.parent_path() / "metadata.json")),
                                                                               viewContext(),
                                                                               annotationView(sceneModel, viewId),
                                                                               pointCloudView(sceneModel, viewId),
@@ -25,8 +24,8 @@ PointCloudViewController::PointCloudViewController(fs::path pcPath) : viewId(IdF
                                                                               addRectangleView(sceneModel, timeline, viewId),
                                                                               statusBarView(sceneModel, IdFactory::getInstance().getId()) {
 
-  annotationPath = utils::dataset::getAnnotationPathForPointCloudPath(pointCloudPath);
-  sceneModel.setPointCloudPath(pointCloudPath); // TODO: Load a new path/cloud when tab is pressed
+  annotationPath = utils::dataset::getAnnotationPathForPointCloudPath(pcPath);
+  sceneModel.setPointCloud(dataset.getCurrentCloud());
   pointCloudView.loadPointCloud();
   sceneModel.activeView = active_view::PointCloudView;
 }
@@ -199,12 +198,11 @@ void PointCloudViewController::undo() {
 }
 
 void PointCloudViewController::nextPointCloud() {
-  pointCloudPath = dataset.next();
-  annotationPath = utils::dataset::getAnnotationPathForPointCloudPath(pointCloudPath);
+  auto pointCloud = dataset.next();
+  annotationPath = utils::dataset::getAnnotationPathForPointCloudPath(dataset.currentPath());
   sceneModel.reset();
-  sceneModel.setPointCloudPath(pointCloudPath);
+  sceneModel.setPointCloud(pointCloud);
   pointCloudView.reload();
   load();
-
 }
 

--- a/src/controllers/point_cloud_view_controller.cc
+++ b/src/controllers/point_cloud_view_controller.cc
@@ -25,7 +25,9 @@ PointCloudViewController::PointCloudViewController(fs::path pcPath) : viewId(IdF
                                                                               statusBarView(sceneModel, IdFactory::getInstance().getId()) {
 
   annotationPath = utils::dataset::getAnnotationPathForPointCloudPath(pcPath);
-  sceneModel.setPointCloud(dataset.getCurrentCloud());
+  auto future = dataset.getCurrentCloud();
+  future.wait();
+  sceneModel.setPointCloud(future.get());
   pointCloudView.loadPointCloud();
   sceneModel.activeView = active_view::PointCloudView;
 }
@@ -198,11 +200,13 @@ void PointCloudViewController::undo() {
 }
 
 void PointCloudViewController::nextPointCloud() {
-  auto pointCloud = dataset.next();
-  annotationPath = utils::dataset::getAnnotationPathForPointCloudPath(dataset.currentPath());
-  sceneModel.reset();
+  auto future = dataset.next();
+  future.wait();
+  auto pointCloud = future.get();
   sceneModel.setPointCloud(pointCloud);
+  sceneModel.reset();
   pointCloudView.reload();
+  annotationPath = utils::dataset::getAnnotationPathForPointCloudPath(dataset.currentPath());
   load();
 }
 

--- a/src/controllers/studio_view_controller.cc
+++ b/src/controllers/studio_view_controller.cc
@@ -30,7 +30,7 @@ StudioViewController::StudioViewController(fs::path datasetPath) : viewId(IdFact
                                                                    addBBoxView(sceneModel, datasetMetadata, timeline, viewId),
                                                                    addRectangleView(sceneModel, timeline, viewId),
                                                                    statusBarView(sceneModel, IdFactory::getInstance().getId()) {
-  sceneModel.setPointCloudPath((datasetPath / "scene" / "cloud.ply").string());
+  pointCloudPath = datasetPath / "scene" / "cloud.ply";
   preview = std::make_shared<controllers::PreviewController>(sceneModel, datasetPath, IdFactory::getInstance().getId());
   addSubController(std::static_pointer_cast<controllers::Controller>(preview));
 }
@@ -151,7 +151,7 @@ bool StudioViewController::keypress(char character, const InputModifier mod) {
   if (mod == ModShift && character == '1') {
     sceneModel.activeView = active_view::MeshView;
   } else if (mod == ModShift && character == '2') {
-    pointCloudView.loadPointCloud();
+    loadPointCloud();
     sceneModel.activeView = active_view::PointCloudView;
     return true;
   } else if (character == 'K') {
@@ -219,3 +219,11 @@ void StudioViewController::undo() {
   timeline.undoCommand();
   refresh();
 }
+
+void StudioViewController::loadPointCloud() {
+  if (sceneModel.getPointCloud() == nullptr) {
+    sceneModel.setPointCloud(std::make_shared<geometry::PointCloud>(pointCloudPath));
+  }
+  pointCloudView.loadPointCloud();
+}
+

--- a/src/model/point_cloud_dataset.cc
+++ b/src/model/point_cloud_dataset.cc
@@ -1,0 +1,58 @@
+#include "model/point_cloud_dataset.h"
+
+namespace model {
+
+PointCloudDataset::PointCloudDataset(fs::path current) : path(current.parent_path()), currentPointCloud(current) {
+  indexPointClouds();
+
+  auto it = find_if(pointClouds.begin(), pointClouds.end(), [&](const fs::path pc) {
+    return pc == current;
+  });
+  currentIndex = it - pointClouds.begin();
+  currentCloud = fetchPointCloud(currentPointCloud);
+  nextCloud = fetchPointCloud(nextPath());
+}
+
+const std::shared_future<PointCloudPtr>& PointCloudDataset::getCurrentCloud() const {
+  return currentCloud;
+}
+
+fs::path PointCloudDataset::currentPath() const { return currentPointCloud; }
+fs::path PointCloudDataset::nextPath() const {
+  int nextIndex = (currentIndex + 1) % int(pointClouds.size());
+  return pointClouds[nextIndex];
+}
+
+std::shared_future<PointCloudPtr> PointCloudDataset::next() {
+  currentIndex = (currentIndex + 1) % int(pointClouds.size());
+  currentPointCloud = pointClouds[currentIndex];
+  currentCloud = nextCloud;
+  nextCloud = fetchPointCloud(nextPath());
+  return currentCloud;
+}
+
+void PointCloudDataset::indexPointClouds() {
+  for (auto& p : fs::directory_iterator(path)) {
+    fs::path file = p.path();
+    std::string extension = file.extension().string();
+    if (extension == ".ply") {
+      pointClouds.push_back(file);
+    }
+  }
+}
+
+std::shared_future<PointCloudPtr> PointCloudDataset::fetchPointCloud(fs::path pcPath) {
+  auto path = nextPath();
+  std::promise<PointCloudPtr> promise;
+  std::shared_future<PointCloudPtr> theFuture = promise.get_future();
+  auto getFunction = [&, theFuture]() -> PointCloudPtr {
+    PointCloudPtr ptr = std::make_shared<geometry::PointCloud>(pcPath.string());
+    promise.set_value(ptr);
+    theFuture.wait();
+    return ptr;
+  };
+  auto result = std::async(std::launch::async, getFunction);
+  return theFuture;
+}
+
+}

--- a/src/scene_model.cc
+++ b/src/scene_model.cc
@@ -69,6 +69,12 @@ void SceneModel::removeKeypoint(const Keypoint& kp) {
   keypoints.erase(iterator);
 }
 
+void SceneModel::reset() {
+  keypoints.clear();
+  boundingBoxes.clear();
+  rectangles.clear();
+}
+
 std::optional<Keypoint> SceneModel::getKeypoint(int id) const {
   for (unsigned int i = 0; i < keypoints.size(); i++) {
     if (keypoints[i].id == id) {
@@ -76,6 +82,11 @@ std::optional<Keypoint> SceneModel::getKeypoint(int id) const {
     }
   }
   return {};
+}
+
+void SceneModel::setPointCloudPath(std::string path) {
+  pointCloud = nullptr;
+  pointCloudPath = path;
 }
 
 void SceneModel::setKeypoint(const Keypoint& updated) {

--- a/src/scene_model.cc
+++ b/src/scene_model.cc
@@ -19,9 +19,6 @@ std::shared_ptr<geometry::TriangleMesh> SceneModel::getMesh() {
 }
 
 std::shared_ptr<geometry::PointCloud> SceneModel::getPointCloud() {
-  if (pointCloud == nullptr) {
-    loadPointCloud();
-  }
   return pointCloud;
 }
 
@@ -84,9 +81,9 @@ std::optional<Keypoint> SceneModel::getKeypoint(int id) const {
   return {};
 }
 
-void SceneModel::setPointCloudPath(std::string path) {
-  pointCloud = nullptr;
-  pointCloudPath = path;
+void SceneModel::setPointCloud(std::shared_ptr<geometry::PointCloud> pc) {
+  pointCloud = pc;
+  rtPointCloud.emplace(pointCloud, pointCloudPointSize);
 }
 
 void SceneModel::setKeypoint(const Keypoint& updated) {
@@ -171,13 +168,6 @@ void SceneModel::loadMesh() {
   if (meshPath) {
     mesh = std::make_shared<geometry::Mesh>(meshPath.value_or("empty"));
     rtMesh.emplace(mesh);
-  }
-}
-
-void SceneModel::loadPointCloud() {
-  if (pointCloudPath) {
-    pointCloud = std::make_shared<geometry::PointCloud>(pointCloudPath.value_or("empty"));
-    rtPointCloud.emplace(pointCloud, pointCloudPointSize);
   }
 }
 

--- a/src/views/point_cloud_view.cc
+++ b/src/views/point_cloud_view.cc
@@ -68,4 +68,11 @@ void PointCloudView::render(const ViewContext3D& context) const {
   bgfx::setIndexBuffer(indexBuffer);
   bgfx::submit(viewId, program);
 }
+
+void PointCloudView::reload() {
+  initialized = false;
+  bgfx::destroy(vertexBuffer);
+  bgfx::destroy(indexBuffer);
+  loadPointCloud();
+}
 } // namespace views


### PR DESCRIPTION
Implements moving from one point cloud to the other using `tab`. 

Pre-fetches the following point cloud in the background to make the wait slightly shorter. There is still a small delay, as the indexing is not done asynchronously, but the wait is manageable on small point clouds. 