### PR TITLE
Fix builds

### DIFF
--- a/include/model/point_cloud_dataset.h
+++ b/include/model/point_cloud_dataset.h
@@ -1,4 +1,5 @@
 #include <filesystem>
+#include <vector>
 #include <memory>
 #include <future>
 #include <thread>
@@ -16,14 +17,16 @@ private:
   std::shared_future<PointCloudPtr> currentCloud, nextCloud;
   std::vector<fs::path> pointClouds;
   int currentIndex = -1;
+
 public:
   PointCloudDataset(fs::path current);
   const std::shared_future<PointCloudPtr>& getCurrentCloud() const;
   fs::path currentPath() const;
   fs::path nextPath() const;
   std::shared_future<PointCloudPtr> next();
+
 private:
   void indexPointClouds();
   std::shared_future<PointCloudPtr> fetchPointCloud(fs::path pcPath);
 };
-}
+} // namespace model

--- a/include/scene_model.h
+++ b/include/scene_model.h
@@ -115,6 +115,7 @@ public:
   void updateRectangle(const Rectangle& rectangle);
 
   void save(fs::path annotationPath) const;
+  void load(fs::path annotationPath);
 
   void loadMesh();
 };

--- a/src/scene_model.cc
+++ b/src/scene_model.cc
@@ -171,6 +171,39 @@ void SceneModel::loadMesh() {
   }
 }
 
+void SceneModel::load(fs::path annotationPath) {
+  nlohmann::json json;
+  std::ifstream file(annotationPath);
+  file >> json;
+  for (auto& point : json["keypoints"]) {
+    auto position = point["position"];
+    auto classId = point["class_id"].get<int>();
+    Keypoint kp(keypoints.size() + 1, classId, Vector3f(position[0].get<float>(), position[1].get<float>(), position[2].get<float>()));
+    keypoints.push_back(kp);
+  }
+  for (auto& bbox : json["bounding_boxes"]) {
+    auto p = bbox["position"];
+    auto orn = bbox["orientation"];
+    auto d = bbox["dimensions"];
+    auto classId = bbox["class_id"];
+    BBox box = {
+        .id = int(boundingBoxes.size()) + 1,
+        .classId = classId,
+        .position = Vector3f(p[0].get<float>(), p[1].get<float>(), p[2].get<float>()),
+        .orientation = Quaternionf(orn["w"].get<float>(), orn["x"].get<float>(), orn["y"].get<float>(), orn["z"].get<float>()),
+        .dimensions = Vector3f(d[0].get<float>(), d[1].get<float>(), d[2].get<float>())};
+    boundingBoxes.push_back(box);
+  }
+
+  for (auto& rectangle : json["rectangles"]) {
+    Rectangle rect(0, rectangle["class_id"],
+                   utils::serialize::toVector3(rectangle["center"]),
+                   utils::serialize::toQuaternion(rectangle["orientation"]),
+                   utils::serialize::toVector2(rectangle["size"]));
+    rectangles.push_back(rect);
+  }
+}
+
 void SceneModel::save(fs::path annotationPath) const {
   nlohmann::json json = nlohmann::json::object();
   if (!keypoints.empty()) {


### PR DESCRIPTION
* `preview` uses the load from scene model, the load logic could probably be moved into a helper so timeline could use the same logic + flexible usage enabled for e.g. preview
* There seemed to be a missing include that is breaking the GH action build